### PR TITLE
Added setOnFinishCallback

### DIFF
--- a/lib/src/showcase/showcase_view.dart
+++ b/lib/src/showcase/showcase_view.dart
@@ -102,7 +102,7 @@ class ShowcaseView {
   final String scope;
 
   /// Triggered when all the showcases are completed.
-  final VoidCallback? onFinish;
+  VoidCallback? onFinish;
 
   /// Triggered when showcase view is dismissed.
   final OnDismissCallback? onDismiss;
@@ -212,6 +212,13 @@ class ShowcaseView {
             ?.values
             .toList() ??
         <ShowcaseController>[];
+  }
+
+  /// Sets the [onFinish] callback.
+  ///
+  /// * [callback] - Callback to set
+  void setOnFinishCallback(VoidCallback callback) {
+    onFinish = callback;
   }
 
   /// Starts showcase with given widget ids after the optional delay.

--- a/lib/src/showcase/showcase_view.dart
+++ b/lib/src/showcase/showcase_view.dart
@@ -87,6 +87,7 @@ class ShowcaseView {
     _hideFloatingWidgetKeys = {
       for (final item in hideFloatingActionWidgetForShowcase) item: true,
     };
+    _onFinish = onFinish;
   }
 
   /// Retrieves last registered [ShowcaseView].
@@ -102,7 +103,7 @@ class ShowcaseView {
   final String scope;
 
   /// Triggered when all the showcases are completed.
-  VoidCallback? onFinish;
+  final VoidCallback? onFinish;
 
   /// Triggered when showcase view is dismissed.
   final OnDismissCallback? onDismiss;
@@ -214,11 +215,13 @@ class ShowcaseView {
         <ShowcaseController>[];
   }
 
+  VoidCallback? _onFinish;
+
   /// Sets the [onFinish] callback.
   ///
   /// * [callback] - Callback to set
   void setOnFinishCallback(VoidCallback callback) {
-    onFinish = callback;
+    _onFinish = callback;
   }
 
   /// Starts showcase with given widget ids after the optional delay.
@@ -366,7 +369,7 @@ class ShowcaseView {
         _onStart();
         if (_activeWidgetId! >= _ids!.length) {
           _cleanupAfterSteps();
-          onFinish?.call();
+          _onFinish?.call();
         }
         OverlayManager.instance.update(show: isShowcaseRunning, scope: scope);
       },


### PR DESCRIPTION

## Summary

This PR modifies the `ShowcaseView` class with the following updates:

- **onFinish Callback Mutability:**  
  Changed the `onFinish` property from `final VoidCallback?` to a mutable `VoidCallback?`. This allows the callback to be reassigned after object construction.

- **Setter Method for onFinish:**  
  Added a new method `setOnFinishCallback(VoidCallback callback)` to explicitly set or update the `onFinish` callback.  
  - This helps developers update the completion handler dynamically as needed.

## Motivation

Previously, the `onFinish` callback was immutable after initialization, limiting flexibility when the callback needed to be changed at runtime. By making the callback mutable and providing a setter, this PR enables greater control over the completion behavior of `ShowcaseView`.

## Changes

- `onFinish` property is now mutable.
- Added `setOnFinishCallback` method with documentation.

## Usage

```dart
showcaseView.setOnFinishCallback(() {
  // Custom behavior on showcase completion
});
```

## Checklist

- [x] Refactored code to allow updating `onFinish`
- [x] Added a setter with documentation
- [ ] Tested new setter for expected behavior

---


